### PR TITLE
updated .gitignore to properly ignore python/q1tableimport.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ db/*.sqlite
 /lib/*
 /include/
 
-/q1tableimport.db
+python/q1tableimport.db
 
 pip-selfcheck.json
 


### PR DESCRIPTION
The line in .gitignore was missing the folder name
